### PR TITLE
change way to get environment variable

### DIFF
--- a/server.php
+++ b/server.php
@@ -12,7 +12,7 @@ cors();
 // Set data directory to data if no one logged in
 // Otherwise to data/<username>
 $dir = "data";
-if (isset($_ENV["TODO_PER_USER_FOLDERS"]) && $_ENV["TODO_PER_USER_FOLDERS"] == 'TRUE') {
+if ( getenv("TODO_PER_USER_FOLDERS") == 'TRUE') {
   $dir = "data/".$_SERVER['PHP_AUTH_USER'];
   if (!file_exists($dir)) {
     mkdir($dir, 0777);


### PR DESCRIPTION
By default, on debian the configuration /etc/php/XX/apache2/php.ini indicates :

```
; This directive determines which super global arrays are registered when PHP ; starts up. G,P,C,E & S are abbreviations for the following respective super ; globals: GET, POST, COOKIE, ENV and SERVER. There is a performance penalty ; paid for the registration of these arrays and because ENV is not as commonly ; used as the others, ENV is not recommended on productions servers. You ; can still get access to the environment variables through getenv() should you ; need to.
; Default Value: "EGPCS"
; Development Value: "GPCS"
; Production Value: "GPCS";
; https://php.net/variables-order
variables_order = "GPCS"
```

This means that the global environment variables are not passed to php with production value.

Using php function getenv, this permits to use SetEnv instruction in apache2 virtualhost configuration without changing php configuration.

The mecanism is the same with php_fpm (common usage with nginx).